### PR TITLE
docs(.verb.md): Fix template path

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -33,6 +33,6 @@ $ gen dest eslint
 
 **Overriding templates**
 
-You can override any of the templates by adding a template of the same name to the `templates` directory in user home. For example, to override the `.editorconfig` template, add a template at the following path `~/templates/.editorconfig`.
+You can override any of the templates by adding a template of the same name to the `templates` directory in user home. For example, to override the `.editorconfig` template, add a template at the following path `~/templates/_editorconfig`.
 
 [docs]: https://github.com/generate/generate/blob/master/docs/


### PR DESCRIPTION
_editorConfig is used instead of .editorConfig
